### PR TITLE
Fix spelling errors + wrong answer

### DIFF
--- a/questions/0667.md
+++ b/questions/0667.md
@@ -14,6 +14,6 @@ echo $i / 2;
 
 <details><summary><b>Answer</b></summary>
 <p>
-  Answer: <strong>A, B</strong>
+  Answer: <strong>A</strong>
 </p>
 </details>

--- a/questions/0726.md
+++ b/questions/0726.md
@@ -14,7 +14,7 @@ echo $language();
 - [ ] A) The script echoes: "This is the PHP function"
 - [ ] B) PHP Parse error: syntax error on line 7
 - [ ] C) Notice: Use of undefined constant _FUNCTION__ - assumed '__FUNCTION__' on line 5
-- [ ] D) an exception is thrwon
+- [ ] D) an exception is thrown
 
 <details><summary><b>Answer</b></summary>
 <p>

--- a/questions/0788.md
+++ b/questions/0788.md
@@ -1,12 +1,12 @@
 [<<< Previous question <<<](0787.md)   Question ID#0788.md   [>>> Next question >>>](0789.md)
 ---
 
-Which of the statements below are true about PHP 7`s new generator-delegation feature?
+Which of the statements below are true about PHP 7's new generator-delegation feature?
 
-- [ ] A) It is writte like this: "yeld from <expression>";
-- [ ] B) It is writte like this: "yeld if <expression>";
-- [ ] C) The delegated expression can be anyting that resolve to an array;
-- [ ] D) The delegated expression can be anyting that resolve to a Traversable;
+- [ ] A) It is written like this: "yield from <expression>";
+- [ ] B) It is written like this: "yield if <expression>";
+- [ ] C) The delegated expression can be anyting that resolves to an array;
+- [ ] D) The delegated expression can be anyting that resolves to a Traversable;
 
 <details><summary><b>Answer</b></summary>
 <p>


### PR DESCRIPTION
A couple of spelling issues were fixed in 0726, 0788.
In 0667, 2 answers were selected, while only one of them was correct: https://3v4l.org/qG1kh