### PR TITLE
Update 0308.md

### DIFF
--- a/questions/0308.md
+++ b/questions/0308.md
@@ -12,10 +12,10 @@ echo ($b < 50 XOR $c == 30) ? "c" : "d";
 ```
 Enter the exact script output
 
-- [ ] A) a
+- [ ] A) ad
 - [ ] B) b
-- [ ] C) c
-- [ ] D) ab
+- [ ] C) ab
+- [ ] D) a
 
 <details><summary><b>Answer</b></summary>
 <p>


### PR DESCRIPTION
The previous answer was wrong. It was specified as option A = 'a' when the answer is 'ad'. None of the answers were correct,  this update changes option A to the correct answer 'ad'. This provides at least one correct answer.